### PR TITLE
FN: Feature - UI 2 Responsiveness

### DIFF
--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -7,7 +7,6 @@ import { randomCards, cards } from '../../public/directory';
 
 import Eye from './p5/Eye';
 import Card from './p5/Card';
-import Inquery from './forms/Inquery';
 import Loader from './Loader.tsx';
 
 import { get_tarot_reading } from '../openai_scripts/get_tarot_reading.ts';
@@ -43,15 +42,11 @@ const Board: FC<Props> = ({
   question,
 }) => {
   const [dealtCards, setDealtCards] = useState<Cards[]>([]);
-  const [chatRes, setChatRes] = useState('');
 
   useEffect(() => {
     if (cards && dealtCards.length === 0) setDealtCards(randomCards(cards))
-  }, [cards])
+  }, [cards]);
 
-  function handleReload(): void {
-    window.location.reload();
-  };
   const times = ['PAST', 'PRESENT', 'FUTURE'];
 
   function readingParser(tarotString: string): [string, string][] {
@@ -119,7 +114,6 @@ const Board: FC<Props> = ({
                   </DropCapInterpretation>
                 )}
               </FlexContentRow>
-    
             </CardReadingRow>
           ))}
         </ReadingContainer>
@@ -135,24 +129,24 @@ const Board: FC<Props> = ({
         {/* @ts-ignore */}
           {dealtCards && dealtCards.map((card, i) => (
             <>
-            <CardReading key={uuidv4()}>
-              <CardHeader>
-                <TitleBox>
-                  <Sm>{times[i]}</Sm>
-                  <span>{card.name}</span>
-                </TitleBox>
-              </CardHeader>
+              <CardReading key={uuidv4()}>
+                <CardHeader>
+                  <TitleBox>
+                    <Sm>{times[i]}</Sm>
+                    <span>{card.name}</span>
+                  </TitleBox>
+                </CardHeader>
 
-              <CardContainer>
-                {/* @ts-ignore */}
-                {dealtCards[i] && (
-                  <Card
-                    key={uuidv4()}
-                    name_short={card.code} /> )}
+                <CardContainer>
+                  {/* @ts-ignore */}
+                  {dealtCards[i] && (
+                    <Card
+                      key={uuidv4()}
+                      name_short={card.code} /> )}
                 </CardContainer>
               </CardReading>
             </>
-            ))}
+          ))}
         </CardBox>
       </LoadingContainer>
     );
@@ -205,6 +199,10 @@ const TitleBox = styled.div`
 const CardBox = styled.div`
   display: flex;
   gap: 2vw;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 `;
 const Sm = styled.span`
   display: inline-block;
@@ -241,9 +239,12 @@ const blink = keyframes`
 `;
 const P = styled.p`
   font-family: Elsie Swash Caps;
-  color: gray;
-  color: red;
+  color: #b57902;
   font-size: 2rem;
+
+  @media (max-width: 768px) {
+    font-size: 1.3rem;
+  }
 `;
 const EyeContainer = styled.div`
   clip-path: polygon(50% 0%, 80% 50%, 50% 100%, 20% 50%);
@@ -296,18 +297,12 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  // height: 100%;
-  // width: 100%;
-  // gap: 5vh;
   z-index: 2;
 `;
 
 const ReadingContainer = styled.div<StyleProps>`
-  // height: 60vh;
-  // width: 80vw;
   max-width: 1200px;
   color: white;
-  // overflow: scroll;
   padding: 15px;
   display: flex;
   flex-direction: column;
@@ -321,19 +316,19 @@ const CardReading = styled.div`
   justify-content: center;
   align-items: center;
   margin-bottom: 5vh;
-`;
-const CardReading1 = styled.div`
-  justify-content: left;
+
+  @media (max-width: 768px) {
+    max-width: 100vw;
+  }
 `;
 
-const CardHeader = styled.span`
+const CardHeader = styled.div`
   font-family: Bagnard;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: white;
   font-size: 2rem;
-  // @media only screen and (max-width: 720px) {
-  //   font-size: 2rem;
-  // }
 `;
 
 const CardP = styled.p`
@@ -341,37 +336,6 @@ const CardP = styled.p`
   font-size: 2rem;
   text-align: center;
   padding: 10px;
-  // @media only screen and (max-width: 720px) {
-  //   font-size: 1rem;
-  // }
-`;
-
-const Reload = styled.button`
-  width: 300px;
-  background: none;
-  border: none;
-  text-align: center;
-  align-self: center;
-  color: #e1c4ca;
-  font-size: 4rem;
-  font-family: 'Amatic SC';
-  font-weight: bold;
-  transform: translateY(-60px);
-  cursor: pointer;
-  transition: all 0.3s linear;
-  &:hover {
-    border: 2px solid #e1c4ca;
-    background: rgba(65, 50, 63, 0.9);
-  }
-  @media only screen and (max-width: 500px) {
-    width: 20vw;
-    font-size: 1rem;
-    transform: translateY(-40px);
-  }
-  @media only screen and (min-width: 701px) and (max-width: 1300px) {
-    font-size: 1.5rem;
-    width: 20vw;
-  }
 `;
 
 const CardReadingRow = styled.div`
@@ -388,6 +352,10 @@ const CardHeaderBlock = styled.div`
   margin-bottom: 15px;
   border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
   padding-bottom: 5px;
+
+  @media (max-width: 768px) {
+    align-items: center;
+  }
 `;
 
 const TimePeriodLabel = styled.span`
@@ -417,14 +385,14 @@ const FlexContentRow = styled.div`
 `;
 
 const CardCanvasWrapper = styled.div`
-  flex-shrink: 0; // Prevents the text from squeezing your canvas smaller
+  flex-shrink: 0;
   width: 240px;
   height: 400px;
   overflow: hidden;
 `;
 
 const DropCapInterpretation = styled.p`
-  font-family: 'Bebas Neue', sans-serif; /* Your original paragraph font choice */
+  font-family: 'Bebas Neue', sans-serif;
   font-size: 1.6rem;
   line-height: 1.4;
   color: #e0e0e0;
@@ -433,14 +401,14 @@ const DropCapInterpretation = styled.p`
 
   /* Drop Cap */
   &::first-letter {
-    font-family: 'Bagnard', 'Elsie Swash Caps', serif; /* Use a dramatic font for dropcap */
+    font-family: 'Bagnard', 'Elsie Swash Caps', serif;
     font-size: 4.8rem;
     float: left;
     line-height: 0.85;
     padding-top: 4px;
     padding-right: 8px;
     padding-left: 3px;
-    color: #e1c4ca; /* Soft rosy-gold highlight accent */
+    color: #e1c4ca;
     font-weight: bold;
   }
 `;

--- a/client/src/components/QuestionBoard.tsx
+++ b/client/src/components/QuestionBoard.tsx
@@ -29,11 +29,11 @@ const QuestionBoard: FC<Props> = ({
 
       <div style={{textAlign: 'center'}}>
         <Question>What weighs upon your mind?</Question>
-        <Textarea 
-           placeholder='Ask the cards your question...'
-           autoCapitalize='sentences'
-           onChange={questionHandler}
-           />
+        <Textarea
+          placeholder='Ask the cards your question...'
+          autoCapitalize='sentences'
+          onChange={questionHandler}
+         />
       </div>
     </>
   );
@@ -63,42 +63,23 @@ const Title = styled.div`
   font-family: 'Lora';
   color: white;
   font-size: 6rem;
+
+  @media (max-width: 768px) {
+    font-size: 3rem;
+  }
 `;
 const Sm = styled.span`
   display: inline-block;
-  font-size: 4rem;
+  font-size: 2rem;
 `;
 const Question = styled.p`
   font-family: Elsie Swash Caps;
   color: #b57902;
   font-size: 2rem;
-`;
-const Button = styled.button`
-  background: none;
-  text-align: center;
-  font-size: 2rem;
-  font-family: 'Amatic SC';
-  font-weight: bold;
-  cursor: pointer;
-  color: #b57902;
-  border: 1px solid #b57902;
-  padding: 20px;
 
-  &: hover {
-    border: 1px solid #e1c4ca;
-    background: rgba(65,50,63,0.9);
-    color: white;
-    transition: all 0.3s linear;
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
   }
-  // @media only screen and (max-width: 500px) {
-  //   width: 20vw;
-  //   font-size: 1rem;
-  //   transform: translateY(-40px)
-  // }
-  // @media only screen and (min-width: 701px) and (max-width: 1300px) {
-  //   font-size: 1.5rem;
-  //   width: 20vw;
-  // }
 `;
 const Textarea = styled.textarea`
   background: rgba(255,255,255,0.1);
@@ -115,6 +96,11 @@ const Textarea = styled.textarea`
     background: rgba(66, 66, 66, 0.9);
     color: white;
     transition: all 0.3s linear;
+  }
+
+  @media (max-width: 768px) {
+    height: 30vh;
+    width: 90vw;
   }
 `;
 

--- a/client/src/components/QuestionBoard.tsx
+++ b/client/src/components/QuestionBoard.tsx
@@ -8,7 +8,6 @@ interface Props {
 const QuestionBoard: FC<Props> = ({
   setter
 }) => {
-  
   // @ts-ignore
   const questionHandler = (e) => {
     e.preventDefault()

--- a/client/src/components/Welcome.tsx
+++ b/client/src/components/Welcome.tsx
@@ -3,17 +3,15 @@ import styled, { keyframes } from 'styled-components';
 
 const Welcome = () => {
   return (
-    <>
-      <WelcomeWrapper>
-        <Divination>
-          <LeftSpike />
-          <span>ESPERI</span>
-          <RightSpike/>
-        </Divination>
-        <Oracle>T<Sm>HE</Sm> O<Sm>RACLE</Sm></Oracle>
-        <Gaze>Gaze into the eye and discover what the cards reveal</Gaze>
-      </WelcomeWrapper>
-    </>
+    <WelcomeWrapper>
+      <Divination>
+        <LeftSpike />
+        <span>ESPERI</span>
+        <RightSpike/>
+      </Divination>
+      <Oracle>T<Sm>HE</Sm> O<Sm>RACLE</Sm></Oracle>
+      <Gaze>Gaze into the eye and discover what the cards reveal</Gaze>
+    </WelcomeWrapper>
   );
 };
 
@@ -31,6 +29,10 @@ const LeftSpike = styled.div`
   background: linear-gradient(#b57902, #000);
   clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
   transform: rotate(270deg);
+
+  @media (max-width: 768px) {
+    height: 60px;
+  }
 `;
 const RightSpike = styled(LeftSpike)`
   transform: rotate(90deg);
@@ -45,7 +47,13 @@ const Divination = styled.div`
   justify-content: center;
   gap: 70px;
   opacity: .7;
-  margin-top: 20rem;
+  margin-top: 15vh;
+
+  @media (max-width: 768px) {
+    gap: 30px;
+    font-size: 1.5rem;
+    margin-top: 8vh;
+  }
 `;
  const Question = styled.p`
   font-size: 2.5rem;
@@ -72,42 +80,33 @@ const Oracle = styled.div`
   font-family: 'Lora';
   color: white;
   font-size: 6rem;
+
+  @media (max-width: 768px) {
+    font-size: 3.5rem;
+  }
+  @media (max-width: 380px) {
+    font-size: 2.8rem;
+  }
 `;
 const Sm = styled.span`
   display: inline-block;
   font-size: 4rem;
+
+  @media (max-width: 768px) {
+    font-size: 2.5rem;
+  }
 `;
 const Gaze = styled.p`
   font-family: Elsie Swash Caps;
   color: gray;
   font-size: 2rem;
-`;
-const Button = styled.button`
-  background: none;
-  text-align: center;
-  font-size: 2rem;
-  font-family: 'Amatic SC';
-  font-weight: bold;
-  cursor: pointer;
-  color: #b57902;
-  border: 1px solid #b57902;
-  padding: 20px;
+  font-wrap: wrap; 
 
-  &: hover {
-    border: 2px solid #e1c4ca;
-    background: rgba(65,50,63,0.9);
-    color: white;
-    transition: all 0.3s linear;
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+    padding: 15px;
+    text-align: center;
   }
-  // @media only screen and (max-width: 500px) {
-  //   width: 20vw;
-  //   font-size: 1rem;
-  //   transform: translateY(-40px)
-  // }
-  // @media only screen and (min-width: 701px) and (max-width: 1300px) {
-  //   font-size: 1.5rem;
-  //   width: 20vw;
-  // }
 `;
 
 export default Welcome;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -57,30 +57,10 @@ const Container = styled.div`
   max-width: 2400px;
   align-self: center;
 
-  // @media only screen and (max-width: 375px) and (pointer: coarse) and (hover: none) {
-  //   height: 90vh;
-  // }
-  // @media only screen and (min-width: 321px) and (max-width: 375px) and (pointer: coarse) and (hover: none) {
-  //   height: 93vh;
-  // }
-  // @media only screen and (min-width: 376px) and (max-width: 500px) and (pointer: coarse) and (hover: none) {
-  //   height: 94vh;
-  // }
-  // @media only screen and (min-width: 501px) and (max-width: 770px) and (pointer: coarse) and (hover: none) {
-  //   height: 92vh;
-  // }
-  // @media only screen and (min-width: 771px) and (max-width: 1000px) and (pointer: coarse) and (hover: none) {
-  //   height: 93vh;
-  // }
-  // @media only screen and (min-width: 1000px) and (max-width: 1300px) and (pointer: coarse) and (hover: none) {
-  //   height: 90vh;
-  // }
-  // @media only screen and (min-width: 750px) and (max-width: 1000px) {
-  //   height: 92vh;
-  // }
-  // @media only screen and (min-width: 1001px) and (max-width: 1300px) {
-  //   height: 92vh;
-  // }
+  @media only screen and (max-width: 375px) and (pointer: coarse) and (hover: none) {
+    height: 90vh;
+  }
+  
 `;
 const Button = styled.button`
   background: none;


### PR DESCRIPTION
Adds mobile-responsive layout and typography across the tarot reading flow so the welcome screen, question input, and card board read well on smaller viewports.

1. Welcome — Scales title, subtitle, and decorative spikes at 768px and 380px breakpoints; switches top spacing from fixed rem to vh for better vertical fit on phones.
2. QuestionBoard — Reduces heading and prompt font sizes on mobile; expands the textarea to 90vw × 30vh for easier typing on touch devices.
3. Board — Stacks the three card columns vertically below 768px; tightens interpretation text and header alignment on narrow screens; fixes loading-state prompt color (red → #b57902).
4. Cleanup — Removes unused styled components, dead state/handlers, and commented-out media queries in Home.tsx, Board.tsx, QuestionBoard.tsx, and Welcome.tsx.